### PR TITLE
Add day selector to itinerary page

### DIFF
--- a/src/components/DaySelector.tsx
+++ b/src/components/DaySelector.tsx
@@ -1,0 +1,25 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { TravelDay } from "@/types/itinerary";
+
+interface DaySelectorProps {
+  days: TravelDay[];
+  selectedDayId: string;
+  onChange: (dayId: string) => void;
+}
+
+export function DaySelector({ days, selectedDayId, onChange }: DaySelectorProps) {
+  return (
+    <Select value={selectedDayId} onValueChange={onChange}>
+      <SelectTrigger className="w-[200px]">
+        <SelectValue placeholder="Seleziona giorno" />
+      </SelectTrigger>
+      <SelectContent>
+        {days.map((day, idx) => (
+          <SelectItem key={day.id} value={day.id}>
+            {`Giorno ${idx + 1} - ${new Date(day.date).toLocaleDateString('it-IT')}`}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `DaySelector` component
- update itinerary page to allow selecting travel day
- render itinerary and stats based on selected day

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_686fb5421cf08326bf65f307142f3a4a