### PR TITLE
Add day selection when editing itinerary items

### DIFF
--- a/src/components/EditItineraryItemForm.tsx
+++ b/src/components/EditItineraryItemForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -26,8 +26,15 @@ export function EditItineraryItemForm({ item, isOpen, onClose, dayId }: EditItin
     estimatedCost: item.estimatedCost || "€0",
     notes: item.notes || ""
   });
-  
-  const { updateItineraryItem } = useItineraryStore();
+  const [selectedDayId, setSelectedDayId] = useState(dayId);
+
+  const { currentTrip, updateItineraryItem, addItineraryItem, removeItineraryItem } = useItineraryStore();
+
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedDayId(dayId);
+    }
+  }, [isOpen, dayId]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -46,7 +53,15 @@ export function EditItineraryItemForm({ item, isOpen, onClose, dayId }: EditItin
       image: getEmojiForType(formData.type)
     };
 
-    updateItineraryItem(dayId, item.id, updates);
+    const updatedItem = { ...item, ...updates };
+
+    if (selectedDayId !== dayId) {
+      removeItineraryItem(dayId, item.id);
+      addItineraryItem(selectedDayId, updatedItem);
+    } else {
+      updateItineraryItem(dayId, item.id, updates);
+    }
+
     toast.success(`${formData.name} aggiornato!`);
     onClose();
   };
@@ -87,6 +102,22 @@ export function EditItineraryItemForm({ item, isOpen, onClose, dayId }: EditItin
               onChange={(e) => setFormData({ ...formData, name: e.target.value })}
               required
             />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="edit-day">Giorno</Label>
+            <Select value={selectedDayId} onValueChange={setSelectedDayId}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {currentTrip?.days.map((day, idx) => (
+                  <SelectItem key={day.id} value={day.id}>
+                    {`Giorno ${idx + 1} - ${new Date(day.date).toLocaleDateString('it-IT')}`}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
 
           <div className="grid grid-cols-2 gap-3">


### PR DESCRIPTION
## Summary
- allow moving an itinerary item to another day
- show a day dropdown in the edit form

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686fb54766608326a0b693a02ebd8925