### PR TITLE
Add travel assistant API helper

### DIFF
--- a/src/components/AIAssistant.tsx
+++ b/src/components/AIAssistant.tsx
@@ -6,6 +6,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Bot, Send, Loader2, MapPin, Clock } from "lucide-react";
 import { toast } from "sonner";
 import { generateGeminiResponse, GeminiMessage } from "@/lib/gemini";
+import { callTravelAssistant } from "@/lib/travelAssistant";
 
 interface Message {
   role: 'user' | 'assistant';
@@ -32,26 +33,40 @@ export function AIAssistant() {
     setIsLoading(true);
 
     try {
-      const prompt: GeminiMessage[] = [
-        ...messages,
-        { role: 'user', content: userMessage }
-      ];
-
-      const aiReply = await generateGeminiResponse(prompt);
+      const aiReply = await callTravelAssistant(userMessage, messages);
 
       setMessages(prev => [
         ...prev,
         { role: 'assistant', content: aiReply || 'Mi dispiace, non ho una risposta al momento.' }
       ]);
-      
+
     } catch (error) {
       console.error('Error contacting AI assistant:', error);
+
+      // Gemini fallback if API key is provided
+      if (import.meta.env.VITE_GEMINI_API_KEY) {
+        try {
+          const prompt: GeminiMessage[] = [
+            ...messages,
+            { role: 'user', content: userMessage }
+          ];
+          const geminiReply = await generateGeminiResponse(prompt);
+          setMessages(prev => [
+            ...prev,
+            { role: 'assistant', content: geminiReply || 'Mi dispiace, non ho una risposta al momento.' }
+          ]);
+          return;
+        } catch (fallbackError) {
+          console.error('Gemini fallback failed:', fallbackError);
+        }
+      }
+
       toast.error('Errore nel contattare l\'assistente AI');
-      
+
       // Provide a helpful fallback response
-      setMessages(prev => [...prev, { 
-        role: 'assistant', 
-        content: 'Mi dispiace, al momento non riesco a connettermi ai miei servizi AI. Tuttavia posso comunque aiutarti con consigli di base! Prova a essere più specifico sulla tua destinazione o su cosa stai cercando. 🗺️' 
+      setMessages(prev => [...prev, {
+        role: 'assistant',
+        content: 'Mi dispiace, al momento non riesco a connettermi ai miei servizi AI. Tuttavia posso comunque aiutarti con consigli di base! Prova a essere più specifico sulla tua destinazione o su cosa stai cercando. 🗺️'
       }]);
     } finally {
       setIsLoading(false);

--- a/src/lib/travelAssistant.ts
+++ b/src/lib/travelAssistant.ts
@@ -1,0 +1,24 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export interface AssistantMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+/**
+ * Calls the hosted `travel-assistant` Edge Function.
+ * @param message The latest user message
+ * @param conversation Optional prior messages for context
+ * @returns The assistant's reply text
+ */
+export async function callTravelAssistant(message: string, conversation: AssistantMessage[] = []): Promise<string> {
+  const { data, error } = await supabase.functions.invoke('travel-assistant', {
+    body: { message, conversation }
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data as any)?.response ?? '';
+}


### PR DESCRIPTION
## Summary
- add `callTravelAssistant` helper that invokes the Supabase edge function
- update `AIAssistant` to use the new helper
- keep Gemini call as optional fallback when `VITE_GEMINI_API_KEY` is set

## Testing
- `npm run lint` *(fails: Unexpected any and other lint issues)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686fb6978aa48326a232443734203959