### PR TITLE
Add AI fallback for itinerary import

### DIFF
--- a/src/lib/travelAssistant.ts
+++ b/src/lib/travelAssistant.ts
@@ -1,0 +1,9 @@
+import { GeminiMessage, generateGeminiResponse } from "./gemini";
+
+export async function callTravelAssistant(message: string, conversation: GeminiMessage[] = []): Promise<string> {
+  const messages: GeminiMessage[] = [
+    ...conversation,
+    { role: 'user', content: message }
+  ];
+  return generateGeminiResponse(messages);
+}


### PR DESCRIPTION
## Summary
- add `callTravelAssistant` helper to invoke Gemini
- enhance `ItineraryImporter` with AI parsing fallback
- show "Analisi con AI…" progress message and report errors when AI fails

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fb699fcdc83268124e010871ba777